### PR TITLE
removing hidden_size from partials, changing trainNet.py argname (no …

### DIFF
--- a/examples/trainNet.py
+++ b/examples/trainNet.py
@@ -69,7 +69,7 @@ parser.add_argument("--seqdur", default=500, type=int,
 parser.add_argument("--numtrials", default=1024, type=int,
                     help="How many trials in an epoch? Best if divisible by batch size (Default: 1024")
 
-parser.add_argument("--hiddensize", default=500, type=int,
+parser.add_argument("--hidden_size", default=500, type=int,
                     help="how many hidden units? (Default: 500")
 
 parser.add_argument("-c", "--contin", default= False, action="store_true",
@@ -199,7 +199,7 @@ else: #create new PredictiveNet and begin training
     env = make_env(args.env, args.envPackage, args.actenc)
     agent = create_agent(args.env, env, args.agent)
     predictiveNet = PredictiveNet(env,
-                                  hidden_size = args.hiddensize,
+                                  hidden_size = args.hidden_size,
                                   pRNNtype = args.pRNNtype,
                                   learningRate = args.lr,
                                   weight_decay = args.weight_decay,

--- a/prnn/utils/Architectures.py
+++ b/prnn/utils/Architectures.py
@@ -710,8 +710,8 @@ thcycRNN_5win_first_prevAct = partial(RolloutRNN, use_ALN = False, k = 5, contin
 """ Log Normal Initialization"""
 
 #use LayerNormCell, no more LogNRNNCell
-lognRNN_rollout = partial(RolloutRNN, use_ALN = False, k = 5, continuousTheta = False, rollout_action = "full", init = "log_normal", hidden_size=800,  sparsity=0.05)
-lognRNN_mask = partial(MaskedRNN, use_LN = True, k = 5, init = "log_normal", hidden_size=800, sparsity=0.05)
+lognRNN_rollout = partial(RolloutRNN, use_ALN = False, k = 5, continuousTheta = False, rollout_action = "full", init = "log_normal", sparsity=0.05)
+lognRNN_mask = partial(MaskedRNN, use_LN = True, k = 5, init = "log_normal", sparsity=0.05)
 
 """ Multimodal pRNNs """ 
 


### PR DESCRIPTION
…underscore) to match

discussed this with @mcum96:

Using `hidden_size` when making the "partial" `logn_mask` network in `Architectures` causes problems when its time to fill in the rest of the arguments in `predictiveNet.py`. It seems calling `partial()` doesn't actually create an the object yet, it just stores the provided args until the rest of them are filled in. In `predictiveNet.py` when that does happen, there are two `hidden_size` parameters passed in, causing an error. We fixed it by removing hidden size from the partial definitions in architectures.

This means that if you want any other hidden_size besides 500 (e.g. 800), make sure to explicitly pass it in to `trainNet.py` as `--hidden_size` (note the underscore, changed to match all the other variable names), or as `PredictiveNet(hidden_size = 800, other_args=...)`