### PR TITLE
fixing dtype issues

### DIFF
--- a/examples/trainNet.py
+++ b/examples/trainNet.py
@@ -164,10 +164,10 @@ parser.add_argument("--continuousTheta", default=False, type=bool,
 parser.add_argument("--eg_weight_decay", default=1e-6, type=float,
                     help="Weight Decay for Exponentiated Gradient Descent (Default: 1e-6)")
 
-parser.add_argument("--eg_lr", default=None,
+parser.add_argument("--eg_lr", default=None, type=float,
                     help="Learning Rate for Exponentiated Gradient Descent (Default: None (do not use EG))")
 
-parser.add_argument("--bias_lr", default=0.1,
+parser.add_argument("--bias_lr", default=0.1, type=float,
                     help="Learning Rate for Biases when using Exponentiated Gradient Descent (Default: 0.1)")
 
 args = parser.parse_args()

--- a/prnn/utils/figures.py
+++ b/prnn/utils/figures.py
@@ -38,7 +38,7 @@ def TrainingFigure(predictiveNet,
     #PFtrainsteps=np.delete(PFtrainsteps,0)
 
     #Final PF panel
-    trainstep = index[PFtrainsteps[numPFpanels-1]]
+    trainstep = index[int(PFtrainsteps[numPFpanels-1])]
     #PFfigs[PFpanel].suptitle(f'Step: {trainstep}')
     place_fields = predictiveNet.TrainingSaver.place_fields[trainstep]
     SI = predictiveNet.TrainingSaver.SI[trainstep]


### PR DESCRIPTION
Fixed dtype issues in two files:
- in `trainNet`, `eg_lr` and `bias_lr` weren't explicitly set to be floats so they were being read as strings
- in `figures.py` there was a similar Pandas issue as #52, where floats were being passed as indices